### PR TITLE
Python3 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # IDE files
 .idea/
+.vscode/
+venv/
 
 # Data
 *.csv

--- a/keep.py
+++ b/keep.py
@@ -1,44 +1,43 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os, bs4, glob, unicodecsv as csv
+import os, bs4, glob, csv
 from dateutil.parser import parse
 from datetime import datetime
+
 files = glob.glob("Keep/*.html")
 notes = []
 
-#Prep CSV file
+# Prep CSV file
 now = datetime.now()
 csvout = "notes_%s.csv" % now.strftime("%Y-%m-%d_%H%M")
-writer = csv.writer(open(csvout, 'wb'))
-writer.writerow(['file','date', 'title', 'content'])
 
-for file in files:
-	print(file)
-	page = open(file)
-	soup = bs4.BeautifulSoup(page.read(), "html.parser")
+with open(csvout, "w") as f:
+    writer = csv.writer(f)
+    writer.writerow(["file", "date", "title", "content"])
 
-	#Make Excel-Friendly date
-	googDate = soup.select('.heading')[0].getText().strip()
-	xlDate = datetime.strftime(parse(googDate), '%m/%d/%Y %H:%M')
+    for file in files:
+        print(file)
+        with open(file, mode="r") as page:
+            soup = bs4.BeautifulSoup(page.read(), "html.parser")
 
-	#Get title
-	if len(soup.select('.title')) == 0:
-		title = ''
-	else:
-		title = soup.select('.title')[0].getText()
+        # Make Excel-Friendly date
+        googDate = soup.select(".heading")[0].getText().strip()
+        xlDate = datetime.strftime(parse(googDate), "%m/%d/%Y %H:%M")
 
-	#Parse Content
-	html = soup.select(".content")[0]
-	#Convert linebreaks
-	for br in soup.find_all("br"):
-		br.replace_with("\n")
-	content = html.getText()
-	
-	note = {
-		"date": xlDate,
-		"title": title,
-		"content": content
-	}
-	writer.writerow([file, note['date'],note['title'],note['content']])
+        # Get title
+        if len(soup.select(".title")) == 0:
+            title = ""
+        else:
+            title = soup.select(".title")[0].getText()
 
-print('\n'+'-'*50 + '\nDone! %s notes saved to %s\n' % (len(files), csvout))
+        # Parse Content
+        html = soup.select(".content")[0]
+        # Convert linebreaks
+        for br in soup.find_all("br"):
+            br.replace_with("\n")
+        content = html.getText()
+
+        note = {"date": xlDate, "title": title, "content": content}
+        writer.writerow([file, note["date"], note["title"], note["content"]])
+
+print("\n" + "-" * 50 + "\nDone! %s notes saved to %s\n" % (len(files), csvout))

--- a/keep.py
+++ b/keep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os, bs4, glob, csv
 from dateutil.parser import parse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 bs4
 dateutils
-unicodecsv


### PR DESCRIPTION
Use built in csv module and context managers

    Use python3 csv module that handles unicode correctly.
    Context managers for files
    Black formated the keep.py
    Tested in py 3.7